### PR TITLE
Pure Rust backend, macOS sandbox, UI polish, auto-update fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           tagName: v__VERSION__
           releaseName: 'RDS SSM Connect v__VERSION__'
           releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           includeUpdaterJson: false
           args: --target ${{ matrix.rust_target }}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3877,7 +3877,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rds-ssm-connect"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -5,12 +5,13 @@ use crate::tunnel::manager::TunnelManager;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, State};
 use tokio::sync::Mutex;
 
 pub type AwsDirState = Arc<std::sync::RwLock<Option<AwsDirAccess>>>;
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GITHUB_REPO: &str = "https://github.com/yarka-guru/connection_app";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UpdateInfo {
@@ -33,12 +34,15 @@ pub async fn check_for_updates(app_handle: AppHandle) -> Result<UpdateInfo, AppE
         .map_err(|e| AppError::General(format!("Failed to get updater: {}", e)))?;
 
     match updater.check().await {
-        Ok(Some(update)) => Ok(UpdateInfo {
-            update_available: true,
-            current_version: CURRENT_VERSION.to_string(),
-            latest_version: Some(update.version.clone()),
-            download_url: None,
-        }),
+        Ok(Some(update)) => {
+            let download_url = format!("{}/releases/tag/v{}", GITHUB_REPO, update.version);
+            Ok(UpdateInfo {
+                update_available: true,
+                current_version: CURRENT_VERSION.to_string(),
+                latest_version: Some(update.version.clone()),
+                download_url: Some(download_url),
+            })
+        }
         Ok(None) => Ok(UpdateInfo {
             update_available: false,
             current_version: CURRENT_VERSION.to_string(),
@@ -57,6 +61,38 @@ pub async fn check_for_updates(app_handle: AppHandle) -> Result<UpdateInfo, AppE
     }
 }
 
+#[cfg(target_os = "linux")]
+fn try_privileged_install(bytes: &[u8]) -> Result<(), AppError> {
+    let current_exe = std::env::current_exe()
+        .map_err(|e| AppError::General(format!("Cannot determine exe path: {}", e)))?;
+
+    let tmp_path = std::env::temp_dir().join("rds-ssm-connect-update");
+    std::fs::write(&tmp_path, bytes)
+        .map_err(|e| AppError::General(format!("Failed to write temp file: {}", e)))?;
+
+    let status = std::process::Command::new("pkexec")
+        .args([
+            "cp",
+            &tmp_path.to_string_lossy(),
+            &current_exe.to_string_lossy(),
+        ])
+        .status();
+
+    let _ = std::fs::remove_file(&tmp_path);
+
+    match status {
+        Ok(s) if s.success() => {
+            let _ = std::process::Command::new("pkexec")
+                .args(["chmod", "+x", &current_exe.to_string_lossy()])
+                .status();
+            Ok(())
+        }
+        _ => Err(AppError::General(
+            "Privileged install cancelled or failed. Try downloading manually.".to_string(),
+        )),
+    }
+}
+
 #[tauri::command]
 pub async fn install_update(app_handle: AppHandle) -> Result<(), AppError> {
     use tauri_plugin_updater::UpdaterExt;
@@ -71,23 +107,50 @@ pub async fn install_update(app_handle: AppHandle) -> Result<(), AppError> {
         .map_err(|e| AppError::General(format!("Failed to check for updates: {}", e)))?
         .ok_or_else(|| AppError::General("No update available".to_string()))?;
 
-    let mut downloaded = 0;
-    update
-        .download_and_install(
-            |chunk_length, content_length| {
-                downloaded += chunk_length;
-                if let Some(total) = content_length {
-                    eprintln!("Downloaded {} of {} bytes", downloaded, total);
-                }
+    // Download with progress events
+    let app = app_handle.clone();
+    let mut downloaded: u64 = 0;
+    let bytes = update
+        .download(
+            move |chunk_length, content_length| {
+                downloaded += chunk_length as u64;
+                let _ = app.emit(
+                    "update-progress",
+                    serde_json::json!({
+                        "phase": "downloading",
+                        "downloaded": downloaded,
+                        "total": content_length,
+                    }),
+                );
             },
-            || {
-                eprintln!("Download complete, installing...");
-            },
+            || {},
         )
         .await
-        .map_err(|e| AppError::General(format!("Failed to download/install update: {}", e)))?;
+        .map_err(|e| AppError::General(format!("Failed to download update: {}", e)))?;
 
-    app_handle.restart();
+    let _ = app_handle.emit(
+        "update-progress",
+        serde_json::json!({ "phase": "installing" }),
+    );
+
+    match update.install(&bytes) {
+        Ok(()) => {
+            app_handle.restart();
+        }
+        Err(e) => {
+            #[cfg(target_os = "linux")]
+            {
+                log::warn!("Standard install failed ({}), trying pkexec fallback", e);
+                if try_privileged_install(&bytes).is_ok() {
+                    app_handle.restart();
+                }
+            }
+            return Err(AppError::General(format!(
+                "Install failed: {}. Try downloading manually from the releases page.",
+                e
+            )));
+        }
+    }
 
     #[allow(unreachable_code)]
     Ok(())

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -35,6 +35,8 @@ let showDeleteConfirm = $state(null)
 let showCloseConfirm = $state(false)
 let isCheckingUpdates = $state(false)
 let updateCheckMessage = $state('')
+let updateProgress = $state(null)
+let updateError = $state(null)
 
 let currentTheme = $state('forest')
 let showSettings = $state(false)
@@ -57,6 +59,7 @@ let unlistenStatus = null
 let unlistenDisconnected = null
 let unlistenConnectionError = null
 let unlistenCloseRequested = null
+let unlistenUpdateProgress = null
 
 // Global keyboard shortcuts
 function handleGlobalKeydown(e) {
@@ -195,6 +198,10 @@ async function initApp() {
     connectingId = null
   }).then((fn) => { unlistenConnectionError = fn })
 
+  listen('update-progress', (ev) => {
+    updateProgress = ev.payload
+  }).then((fn) => { unlistenUpdateProgress = fn })
+
   // Load saved data + version with timeout
   try {
     const [savedResult, versionResult] = await withTimeout(
@@ -329,6 +336,10 @@ async function continueAfterSetup() {
     connectingId = null
   }).then((fn) => { unlistenConnectionError = fn })
 
+  listen('update-progress', (ev) => {
+    updateProgress = ev.payload
+  }).then((fn) => { unlistenUpdateProgress = fn })
+
   // Load saved data + version
   try {
     const [savedResult, versionResult] = await withTimeout(
@@ -364,6 +375,7 @@ onDestroy(() => {
   unlistenDisconnected?.()
   unlistenConnectionError?.()
   unlistenCloseRequested?.()
+  unlistenUpdateProgress?.()
 })
 
 async function confirmClose() {
@@ -604,23 +616,31 @@ async function handleInstallUpdate() {
   if (!updateInfo?.updateAvailable || isUpdating) return
 
   isUpdating = true
-  statusMessage = 'Downloading update...'
+  updateError = null
+  updateProgress = null
 
   try {
     await invoke('install_update')
     // App should auto-restart and never reach here, but just in case:
     isUpdating = false
     showUpdateBanner = false
-    statusMessage = 'Update installed successfully.'
   } catch (err) {
-    errorMessage = `Update failed: ${err}`
+    updateError = `${err}`
     isUpdating = false
-    statusMessage = ''
+    updateProgress = null
+  }
+}
+
+function handleManualDownload() {
+  if (updateInfo?.downloadUrl) {
+    invoke?.('open_url', { url: updateInfo.downloadUrl })
   }
 }
 
 function handleDismissUpdate() {
   showUpdateBanner = false
+  updateError = null
+  updateProgress = null
 }
 
 function handleProjectChange(newProject) {
@@ -743,12 +763,16 @@ const isAlreadySaved = $derived(
     </div>
   {:else}
     <div class="app-container">
-      {#if showUpdateBanner && updateInfo?.updateAvailable}
+      {#if (showUpdateBanner && updateInfo?.updateAvailable) || updateError}
         <UpdateBanner
           {updateInfo}
           {isUpdating}
+          {updateProgress}
+          {updateError}
+          downloadUrl={updateInfo?.downloadUrl}
           onInstall={handleInstallUpdate}
           onDismiss={handleDismissUpdate}
+          onManualDownload={handleManualDownload}
         />
       {/if}
 

--- a/src/lib/UpdateBanner.svelte
+++ b/src/lib/UpdateBanner.svelte
@@ -1,5 +1,20 @@
 <script>
-const { updateInfo = null, isUpdating = false, onInstall, onDismiss } = $props()
+const {
+  updateInfo = null,
+  isUpdating = false,
+  updateProgress = null,
+  updateError = null,
+  downloadUrl = null,
+  onInstall,
+  onDismiss,
+  onManualDownload,
+} = $props()
+
+const progressPercent = $derived(
+  updateProgress?.downloaded && updateProgress?.total
+    ? Math.round((updateProgress.downloaded / updateProgress.total) * 100)
+    : null,
+)
 
 function handleInstall() {
   onInstall?.()
@@ -8,9 +23,38 @@ function handleInstall() {
 function handleDismiss() {
   onDismiss?.()
 }
+
+function handleManualDownload() {
+  onManualDownload?.()
+}
 </script>
 
-{#if updateInfo?.updateAvailable}
+{#if updateError}
+  <div class="update-banner update-banner--error">
+    <div class="update-icon update-icon--error">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <circle cx="9" cy="9" r="8" stroke="currentColor" stroke-width="1.5"/>
+        <path d="M9 5v5M9 12.5v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+    </div>
+    <div class="update-text">
+      <span class="update-message update-message--error">Update failed</span>
+      <span class="error-detail">{updateError}</span>
+    </div>
+    <div class="update-actions">
+      {#if downloadUrl}
+        <button class="btn-manual" onclick={handleManualDownload}>
+          Download Manually
+        </button>
+      {/if}
+      <button class="btn-dismiss" onclick={handleDismiss} aria-label="Dismiss update notification">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path d="M3 3l8 8M11 3l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+{:else if updateInfo?.updateAvailable}
   <div class="update-banner">
     <div class="update-icon">
       {#if isUpdating}
@@ -23,8 +67,23 @@ function handleDismiss() {
       {/if}
     </div>
     <div class="update-text">
-      {#if isUpdating}
-        <span class="update-message">Downloading update...</span>
+      {#if isUpdating && updateProgress?.phase === 'installing'}
+        <span class="update-message">Installing update...</span>
+      {:else if isUpdating}
+        <span class="update-message">
+          Downloading update...
+          {#if progressPercent !== null}
+            <strong>{progressPercent}%</strong>
+          {/if}
+        </span>
+        {#if updateProgress?.total}
+          <div class="progress-bar-track">
+            <div
+              class="progress-bar-fill"
+              style="width: {progressPercent ?? 0}%"
+            ></div>
+          </div>
+        {/if}
       {:else}
         <span class="update-message">
           Update available: <strong>v{updateInfo.latestVersion}</strong>
@@ -62,6 +121,10 @@ function handleDismiss() {
     animation: slideIn 0.3s ease-out;
   }
 
+  .update-banner--error {
+    border-color: rgba(var(--color-error-rgb), 0.3);
+  }
+
   @keyframes slideIn {
     from {
       opacity: 0;
@@ -85,6 +148,11 @@ function handleDismiss() {
     flex-shrink: 0;
   }
 
+  .update-icon--error {
+    background: rgba(var(--color-error-rgb), 0.2);
+    color: var(--color-error-soft);
+  }
+
   .spinner {
     width: 16px;
     height: 16px;
@@ -102,7 +170,7 @@ function handleDismiss() {
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 4px;
     min-width: 0;
   }
 
@@ -115,9 +183,35 @@ function handleDismiss() {
     color: var(--accent-primary-light);
   }
 
+  .update-message--error {
+    color: var(--color-error-light);
+    font-weight: 600;
+  }
+
+  .error-detail {
+    font-size: 0.75rem;
+    color: var(--color-error-soft);
+    line-height: 1.4;
+  }
+
   .current-version {
     font-size: 0.7rem;
     color: var(--text-secondary);
+  }
+
+  .progress-bar-track {
+    width: 100%;
+    height: 4px;
+    background: rgba(var(--accent-primary-rgb), 0.15);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .progress-bar-fill {
+    height: 100%;
+    background: var(--accent-primary);
+    border-radius: 2px;
+    transition: width 0.3s ease;
   }
 
   .update-actions {
@@ -145,6 +239,28 @@ function handleDismiss() {
   }
 
   .btn-install:active {
+    transform: var(--press-scale);
+  }
+
+  .btn-manual {
+    padding: 8px 16px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    background: rgba(var(--glass-rgb), 0.08);
+    border: 1px solid rgba(var(--glass-rgb), 0.15);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s;
+    white-space: nowrap;
+  }
+
+  .btn-manual:hover {
+    background: rgba(var(--glass-rgb), 0.12);
+    border-color: rgba(var(--glass-rgb), 0.25);
+  }
+
+  .btn-manual:active {
     transform: var(--press-scale);
   }
 


### PR DESCRIPTION
## Summary

- **Pure Rust backend** — replace Node.js sidecar with native Rust modules for AWS operations, SSM tunnel (WebSocket), SSO login, config management
- **macOS App Sandbox** — security-scoped bookmarks for `~/.aws` access, setup screen on first launch, project import flow
- **UI polish** — forest theme with warm gold accents, theme switcher (5 themes), cleaned up CLI output
- **Auto-update fix** — publish releases immediately (`releaseDraft: false`), download progress bar, Linux pkexec fallback for AppImage, manual download link on failure
- **Housekeeping** — remove stale JS source/tests, clean up .gitignore/.npmignore, fix SSO token date format

## Test plan

- [ ] `cargo test` — 17 tests pass
- [ ] `cargo check` — compiles clean (gui + cli)
- [ ] `npm run build:vite` — frontend builds clean
- [ ] `npm run dev:gui` — app launches, connections work end-to-end
- [ ] Verify update progress events appear in dev console during update flow
- [ ] Tag a test release and confirm it publishes (not draft) with `latest.json` served
- [ ] Linux: build AppImage, verify pkexec prompt on privileged install failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)