### PR TITLE
Bump version to 3.7.1

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -102,7 +102,7 @@ jobs:
             desc "Secure tunneling via AWS SSM"
             homepage "https://github.com/yarka-guru/connection_app"
 
-            depends_on macos: ">= :monterey"
+            depends_on macos: :monterey
             depends_on formula: "yarka-guru/tap/connection-app-cli"
 
             app "ConnectionApp.app"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.7.1] - 2026-06-22
+
+### Fixed
+- Homebrew cask no longer emits a deprecation warning on `brew` operations:
+  `depends_on macos` now uses the symbol form (`:monterey`) instead of the
+  deprecated string-comparison form (`">= :monterey"`). The fix lands in both
+  the published cask and the `update-homebrew` workflow that regenerates it,
+  so future releases keep it. The macOS minimum (Monterey or newer) is
+  unchanged.
+
+### Changed
+- Dependency maintenance: grouped Cargo (9 crates), npm (2 packages), and
+  GitHub Actions (`actions/checkout` 6→7) updates (#26, #27, #28).
+
 ## [3.7.0] - 2026-06-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "connection_app",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "connection_app",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connection_app",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Secure tunneling through AWS SSM",
   "license": "MIT",
   "author": "Iaroslav Pyrogov",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "connection-app"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connection-app"
-version = "3.7.0"
+version = "3.7.1"
 description = "Secure tunneling through AWS SSM"
 authors = ["Iaroslav Pyrogov"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ConnectionApp",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "identifier": "com.connection-app.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Patch release rolling up the merged dependency updates plus the Homebrew deprecation fix.

## Changes
- **Homebrew deprecation fix**: `update-homebrew.yml` now generates `depends_on macos: :monterey` instead of the deprecated string-comparison form `depends_on macos: ">= :monterey"`. This is the workflow that regenerates the tap cask on every release, so the fix persists. The published cask was fixed directly in [homebrew-tap#1](https://github.com/yarka-guru/homebrew-tap/pull/1). The macOS minimum (Monterey or newer) is **unchanged** — `:monterey` is the equivalent minimum-version requirement, so newer macOS (incl. Tahoe) installs fine.
- **Version bump** 3.7.0 → 3.7.1 across package.json, lockfiles, Cargo.toml, tauri.conf.json.
- **Dependency maintenance** already merged to main: Cargo group (#28), npm group (#26), `actions/checkout` 6→7 (#27).

Tagging `v3.7.1` after merge triggers the Release build + auto-updates the tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)