### PR TITLE
fix(tunnel): smux keepalive every 10s — agent killed idle sessions at 30s (v3.7.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connection_app",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "Secure tunneling through AWS SSM",
   "license": "MIT",
   "author": "Iaroslav Pyrogov",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "connection-app"
-version = "3.7.2"
+version = "3.7.3"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connection-app"
-version = "3.7.2"
+version = "3.7.3"
 description = "Secure tunneling through AWS SSM"
 authors = ["Iaroslav Pyrogov"]
 edition = "2024"

--- a/src-tauri/src/tunnel/native.rs
+++ b/src-tauri/src/tunnel/native.rs
@@ -475,6 +475,14 @@ async fn start_basic_port_forwarding(
                         continue;
                     }
 
+                    log::debug!(
+                        "Inbound SSM message: type={}, seq={}, payload_type={}, payload_len={}",
+                        agent_msg.message_type,
+                        agent_msg.sequence_number,
+                        agent_msg.payload_type,
+                        agent_msg.payload.len()
+                    );
+
                     match agent_msg.message_type.as_str() {
                         OUTPUT_STREAM_DATA => {
                             // Always acknowledge
@@ -1205,6 +1213,14 @@ pub async fn start_multiplexed_port_forwarding(
                         continue;
                     }
 
+                    log::debug!(
+                        "Inbound SSM message: type={}, seq={}, payload_type={}, payload_len={}",
+                        agent_msg.message_type,
+                        agent_msg.sequence_number,
+                        agent_msg.payload_type,
+                        agent_msg.payload.len()
+                    );
+
                     match agent_msg.message_type.as_str() {
                         OUTPUT_STREAM_DATA => {
                             // Always acknowledge
@@ -1322,6 +1338,12 @@ pub async fn start_multiplexed_port_forwarding(
             let seq = outgoing_seq_smux.fetch_add(1, Ordering::Relaxed);
             let msg = build_data_message(&frame_data, seq);
             let serialized = msg.serialize();
+            log::debug!(
+                "Smux frame -> SSM data message: seq={}, frame_cmd={}, frame_len={}",
+                seq,
+                frame_data.get(1).copied().unwrap_or(255),
+                frame_data.len()
+            );
 
             {
                 let mut ob = outgoing_buffer_smux.lock().await;

--- a/src-tauri/src/tunnel/smux.rs
+++ b/src-tauri/src/tunnel/smux.rs
@@ -27,7 +27,15 @@ const SMUX_HEADER_SIZE: usize = 8;
 const MAX_FRAME_SIZE: usize = 65535;
 
 /// Keepalive interval in seconds.
-const KEEPALIVE_INTERVAL_SECS: u64 = 30;
+///
+/// MUST be well below the SSM agent's smux KeepAliveTimeout (30s, xtaci/smux
+/// DefaultConfig). The agent closes the whole session (`channel_closed`) if it
+/// receives no frame — data or NOP — for 30s. Sending every 30s created a
+/// millisecond-level race against that deadline: whenever a NOP arrived late
+/// (network jitter, scheduling), the agent hung up ~30s after the last frame,
+/// producing constant tunnel flapping on idle connections. 10s matches the
+/// official session-manager-plugin (xtaci/smux KeepAliveInterval), a 3x margin.
+const KEEPALIVE_INTERVAL_SECS: u64 = 10;
 
 // --- Smux commands ---
 
@@ -341,7 +349,9 @@ impl SmuxSession {
 
             // Send NOP keepalive
             let nop = SmuxFrame::nop().serialize();
+            log::debug!("Smux NOP keepalive queued ({} bytes)", nop.len());
             if self.frame_tx.send(nop).await.is_err() {
+                log::debug!("Smux NOP keepalive: frame channel closed, stopping keepalive");
                 break;
             }
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ConnectionApp",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "identifier": "com.connection-app.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## The real root cause of today's outage

Every developer's ConnectionApp tunnel (prod **and** stage, every machine) flapped: connect → dead ~30s later → reconnect loop. Raw `aws ssm start-session` was stable throughout. Debug wire capture pinned it:

```
18:56:23  Sent SYN flag to SSM agent (multiplexed mode)
18:56:55  Channel closed by agent: {"MessageType":"channel_closed", ...}   ← +32s
```

**Mechanism** (confirmed in amazon-ssm-agent source):
- The app reports smux client version `1.2.0.0` < the agent's `muxKeepAliveDisabledAfterThisClientVersion = "1.2.331.0"` gate → agent runs `smux.DefaultConfig()` → **KeepAliveTimeout = 30s enforced**: no frame for 30s ⇒ session killed.
- The official plugin reports a newer version → timer disabled → why raw sessions never die.
- Our `KEEPALIVE_INTERVAL_SECS` was **30 — exactly the deadline**. A millisecond race every cycle; jitter ⇒ idle tunnels die at ~30-32s. Query traffic resets the timer, masking the bug (hence months of "intermittent" flapping: 2026-03-19, 05-12, 06-16 storms).

## Fix
Send NOPs every **10s** (matches xtaci/smux client `KeepAliveInterval`, 3× margin). Deliberately **not** bumping the reported client version past the gate — other agent behaviors are version-gated.

## Verification (A/B on bastion-prod, us-west-1, agent 3.3.3598.0)
| | keepalive | outcome |
|---|---|---|
| control v3.7.2 | 30s | `channel_closed` at **+32s** |
| this PR | 10s | **175s+ idle, 0 closes**, agent ACKs each NOP + sends its own NOPs back, live `psql` through tunnel OK |

Plus: `cargo check` (GUI+CLI) ✅ · `clippy -D warnings` ✅ · 66 tests ✅

Also adds debug-level wire logging (NOP sends, frame wraps, inbound SSM message types) — the instrumentation that made diagnosis possible; zero cost with logger off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)