### PR TITLE
fix(tunnel): dedup retransmitted handshake messages — random 32s session deaths (v3.7.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connection_app",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Secure tunneling through AWS SSM",
   "license": "MIT",
   "author": "Iaroslav Pyrogov",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "connection-app"
-version = "3.7.3"
+version = "3.7.4"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connection-app"
-version = "3.7.3"
+version = "3.7.4"
 description = "Secure tunneling through AWS SSM"
 authors = ["Iaroslav Pyrogov"]
 edition = "2024"

--- a/src-tauri/src/tunnel/manager.rs
+++ b/src-tauri/src/tunnel/manager.rs
@@ -25,8 +25,6 @@ const AUTO_RECONNECT_DELAY_MS: u64 = 3000;
 
 // Health check constants
 const HEALTH_CHECK_INTERVAL_SECS: u64 = 30;
-const HEALTH_CHECK_TIMEOUT_MS: u64 = 5000;
-const HEALTH_CHECK_DEGRADED_MS: u64 = 5000;
 
 // Validation patterns
 static PROFILE_SAFE_PATTERN: std::sync::LazyLock<Regex> =
@@ -825,7 +823,8 @@ impl TunnelManager {
     }
 
     /// Spawn a background health check task for a connection.
-    /// Periodically attempts a TCP connect to localhost:port to verify the tunnel is alive.
+    /// Periodically verifies the tunnel's local listener is still bound (via a
+    /// bind-conflict probe — never by connecting, which would create tunnel traffic).
     fn spawn_health_check(
         app_handle: &AppHandle,
         connection_id: &str,
@@ -849,25 +848,24 @@ impl TunnelManager {
                     break;
                 }
 
-                let check_start = std::time::Instant::now();
+                // Check that the tunnel's local listener is still bound WITHOUT
+                // opening a TCP connection to it. Connecting (the old approach)
+                // was actively harmful in multiplexed mode: every probe opened a
+                // real smux stream, which made the agent dial the remote host
+                // (RDS/VNC) and tear it down again — every 30 seconds, for the
+                // lifetime of every connection. A bind attempt gives the same
+                // signal (listener present) with zero tunnel traffic: if the
+                // port is held by our listener, bind fails with AddrInUse.
                 let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
-
-                let status = match tokio::time::timeout(
-                    tokio::time::Duration::from_millis(HEALTH_CHECK_TIMEOUT_MS),
-                    tokio::net::TcpStream::connect(addr),
-                )
-                .await
-                {
-                    Ok(Ok(_stream)) => {
-                        let elapsed = check_start.elapsed().as_millis() as u64;
-                        if elapsed > HEALTH_CHECK_DEGRADED_MS {
-                            "degraded"
-                        } else {
-                            "healthy"
-                        }
+                let status = match std::net::TcpListener::bind(addr) {
+                    // Bind succeeded — nothing is listening on the port anymore.
+                    Ok(sock) => {
+                        drop(sock);
+                        "unhealthy"
                     }
-                    Ok(Err(_)) => "unhealthy",
-                    Err(_) => "unhealthy", // timeout
+                    Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => "healthy",
+                    // Unexpected bind error (permissions etc.) — can't conclude.
+                    Err(_) => "degraded",
                 };
 
                 let now_ms = std::time::SystemTime::now()

--- a/src-tauri/src/tunnel/websocket.rs
+++ b/src-tauri/src/tunnel/websocket.rs
@@ -70,6 +70,13 @@ pub async fn open_data_channel_with_version(
     let mut handshake_complete = false;
     let mut client_seq: i64 = 0; // our outgoing sequence counter
     let mut expected_server_seq: i64 = 0; // what we expect from the agent next
+    // Cached serialized HandshakeResponse so a retransmitted HandshakeRequest can
+    // be answered with the IDENTICAL bytes (same sequence number). Responding to a
+    // duplicate request with a fresh sequence number is a protocol violation that
+    // desyncs the agent's expected-incoming counter and jams its handshake state
+    // machine: it stops acking everything we send, retransmits handshake_complete
+    // every 200ms for ~30s, then closes the channel ("channel_closed" ~32s in).
+    let mut cached_response: Option<Vec<u8>> = None;
 
     while !handshake_complete {
         let ws_msg = ws
@@ -85,13 +92,43 @@ pub async fn open_data_channel_with_version(
 
                 match msg.message_type.as_str() {
                     OUTPUT_STREAM_DATA => {
-                        // Send acknowledge for every output_stream_data
+                        // Always acknowledge — even duplicates: the agent retransmits
+                        // when our previous ack was lost or slow, so re-acking is how
+                        // the retransmission stops.
                         let ack = build_acknowledge(&msg);
                         ws.send(Message::Binary(ack.serialize().into()))
                             .await
                             .map_err(|e| format!("Failed to send ack: {}", e))?;
 
-                        // Advance expected server sequence (agent uses single counter)
+                        // Deduplicate by sequence number (agent uses a single counter).
+                        // A retransmitted message MUST NOT advance our expected counter
+                        // or be processed twice.
+                        if msg.sequence_number != expected_server_seq {
+                            log::info!(
+                                "Duplicate/out-of-order handshake message: seq={}, expected={}, payload_type={} — re-acked, {}",
+                                msg.sequence_number,
+                                expected_server_seq,
+                                msg.payload_type,
+                                if msg.payload_type == PAYLOAD_HANDSHAKE_REQUEST {
+                                    "resending cached response"
+                                } else {
+                                    "dropping"
+                                }
+                            );
+                            // If the agent re-sent the HandshakeRequest, our response may
+                            // have been lost — resend the exact same response bytes
+                            // (idempotent: same sequence number, same content).
+                            if msg.payload_type == PAYLOAD_HANDSHAKE_REQUEST
+                                && let Some(ref resp) = cached_response
+                            {
+                                ws.send(Message::Binary(resp.clone().into()))
+                                    .await
+                                    .map_err(|e| {
+                                        format!("Failed to resend HandshakeResponse: {}", e)
+                                    })?;
+                            }
+                            continue;
+                        }
                         expected_server_seq += 1;
 
                         match msg.payload_type {
@@ -108,7 +145,9 @@ pub async fn open_data_channel_with_version(
                                     client_seq,
                                     client_version,
                                 );
-                                ws.send(Message::Binary(response.serialize().into()))
+                                let serialized = response.serialize();
+                                cached_response = Some(serialized.clone());
+                                ws.send(Message::Binary(serialized.into()))
                                     .await
                                     .map_err(|e| {
                                         format!("Failed to send HandshakeResponse: {}", e)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ConnectionApp",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "identifier": "com.connection-app.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## The second killer (and why v3.7.3 wasn't enough)

v3.7.3 fixed the deterministic idle-session death (smux keepalive race). Sessions **still** died at ~32s randomly — including the GUI right after connecting, which is what developers keep reporting.

### Root cause
The data-channel handshake loop had **no sequence-number dedup**. The agent retransmits unacked messages every 200 ms; when our ack was slow (normal jitter — **the race fired in 4 of 8 test sessions this morning**), the client:
- counted the duplicate → desynced `expected_incoming`, and
- answered a duplicated `HandshakeRequest` with a **second `HandshakeResponse` on a new sequence number** — a protocol violation.

The agent's handshake state machine jams: it acks nothing we send, retransmits `handshake_complete` every 200 ms ×~150 (**= the 32-second signature**), then closes the channel.

Wire forensics of a doomed session (all captured):
```
Post-handshake seq: outgoing=2, expected_incoming=3     ← healthy sessions: 1 / 2
Inbound: output_stream_data seq=1 payload_type=7 ×159   ← 5/sec handshake_complete flood
inbound acknowledge count: 0                            ← agent deaf to us
Channel closed by agent (+32s)
```

### Fix (matches official session-manager-plugin semantics)
- Always ack incoming handshake messages **including duplicates** (re-acking stops the retransmission)
- Only process + advance `expected_incoming` when `sequence_number` matches; drop dups after acking
- Answer a retransmitted `HandshakeRequest` by resending the **cached identical** `HandshakeResponse` (same seq — idempotent)

### Also: health-check probe no longer generates tunnel traffic
The GUI probed by TCP-connecting to the local port every 30 s — in multiplexed mode each probe opened a real smux stream, making the agent **dial RDS/VNC and drop it, every 30 s, per connection, forever**. Now a bind-conflict check: same signal, zero traffic.

## Verification
- 8/8 fixed sessions healthy against bastion-prod; dedup path engaged in 4/8 and every one stayed alive with agent acks flowing
- `cargo check` (GUI+CLI) ✅ · `clippy -D warnings` ✅ · 66 tests ✅

Known cosmetic (out of scope): agent logs 2-3 `getInteger failed: Offset is invalid` per session start — non-fatal, origin TBD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6JDMheBmSXrQQ8opbxqAM