### PR TITLE
fix(release): build AppImage so Linux auto-update works (v3.7.6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,10 +121,17 @@ jobs:
             fi
           done
 
+          # Every target in the matrix produces an updater artifact. A missing one
+          # means latest.json will advertise a URL that 404s with an empty signature,
+          # so fail loudly rather than shipping a silently broken updater (v3.7.5:
+          # "appimage" was absent from tauri.conf.json bundle targets and this
+          # exited 0, so the job stayed green while Linux auto-update was dead).
           if [ -z "$UPDATER_FILE" ]; then
-            echo "WARNING: No updater artifact found"
+            echo "ERROR: No updater artifact found for ${{ matrix.rust_target }}"
+            echo "Expected one of: *.app.tar.gz (macOS), *.AppImage (Linux), *-setup.exe (Windows)"
+            echo "Bundle contents:"
             find "$BUNDLE" -type f 2>/dev/null | head -20
-            exit 0
+            exit 1
           fi
 
           echo "Signing: $UPDATER_FILE"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connection_app",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "description": "Secure tunneling through AWS SSM",
   "license": "MIT",
   "author": "Iaroslav Pyrogov",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "connection-app"
-version = "3.7.5"
+version = "3.7.6"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "connection-app"
-version = "3.7.5"
+version = "3.7.6"
 description = "Secure tunneling through AWS SSM"
 authors = ["Iaroslav Pyrogov"]
 edition = "2024"
+# Floor set by the AWS SDK (aws-smithy-* 1.2+). CI tracks latest stable and will
+# not catch a regression here — this makes an old local toolchain fail clearly.
+rust-version = "1.94.1"
 default-run = "connection-app"
 license = "MIT"
 repository = "https://github.com/yarka-guru/connection_app"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ConnectionApp",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "identifier": "com.connection-app.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:vite",
@@ -27,7 +27,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["deb", "rpm", "nsis", "dmg", "app"],
+    "targets": ["deb", "rpm", "appimage", "nsis", "dmg", "app"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## The bug

v3.7.5 restored the Linux release matrix and successfully shipped `.deb`/`.rpm` for both architectures. But Linux **auto-update is still dead**: `latest.json` advertises AppImage URLs that 404, with empty signatures.

```
ConnectionApp_3.7.5_amd64.AppImage    -> 404
ConnectionApp_3.7.5_aarch64.AppImage  -> 404
linux-x86_64   sig=EMPTY
linux-aarch64  sig=EMPTY
```

## Root cause

`tauri.conf.json` bundle targets never included `"appimage"`:

```json
"targets": ["deb", "rpm", "nsis", "dmg", "app"]
```

So no AppImage is built. The release workflow's signing step globs for `appimage/*.AppImage`, finds nothing, prints a warning and **`exit 0`** — the job goes green having produced no signature. Meanwhile `generate-update-json.js` emits Linux AppImage URLs unconditionally, so the manifest points at files that never existed.

Tauri's Linux updater supports **AppImage only** — `.deb`/`.rpm` cannot self-update, so shipping those alone can't fix it.

**Not a regression:** v3.7.4 has identical empty Linux signatures. But v3.7.5 is the first release to actually ship Linux packages, so it created the population that hits the dead updater.

## Fixes

| Change | Why |
|---|---|
| `tauri.conf.json`: add `"appimage"` to targets | Produces the artifact the updater and signing step need |
| `release.yml`: signing step `exit 0` → `exit 1` | Every matrix target produces an updater artifact; a missing one means a broken manifest. This soft-failure is *exactly* why v3.7.5 shipped green and broken |
| `Cargo.toml`: `rust-version = "1.94.1"` | Floor set by `aws-smithy-*` 1.2+. CI tracks latest stable so it never catches this; an old local toolchain hits a cryptic resolution error instead |

The MSRV declaration is verified — against a 1.93.1 toolchain cargo now reports `connection-app@3.7.6 requires rustc 1.94.1` directly, rather than only naming transitive crates.

## Verification

- `biome check` clean; `npm run build:vite` ok
- `cargo check --locked` ok; **66 tests pass**; `cargo check --locked --no-default-features` ok
- `tauri.conf.json` + `release.yml` parse; targets resolve as intended
- MSRV guard confirmed against 1.93.1

**Not verified:** AppImage bundling has never run in this repo — the release matrix is its first real exercise, aarch64 especially. The `exit 1` means it now fails loudly rather than silently if it doesn't produce an artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)